### PR TITLE
Fix for shorthand property names bug

### DIFF
--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -227,8 +227,8 @@ export const mixin = {
             }
 
             const options = (this.type === 'heatmap')
-                ? {...baseOptions, ...heatMapOptions}
-                : {...baseOptions, ...chartOptions}
+                ? {baseOptions, heatMapOptions}
+                : {baseOptions, chartOptions}
 
             this.chart = new Chart(`#${this.id}`, options)
         },


### PR DESCRIPTION
Compiling the package throws a syntax error after the latest update due to the way that the shorthand property names are called for `options`.

See the error here on [RunKit](https://npm.runkit.com/vue2-frappe).