### PR TITLE
Bump the package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue2-frappe",
-  "version": "1.0.27",
+  "version": "1.0.29",
   "description": "A Vue 2 integration using Frappe Charts",
   "main": "src/index.js",
   "repository": "https://www.github.com/JustSteveKing/vue2-frappe",


### PR DESCRIPTION
I forgot to include this in the last PR. 

Since NPM already had `1.0.28` published, the last commit got ignored. I bumped the version one more time in order to kick off the GitHub workflow. Should publish automatically now!