### PR TITLE
Debounced updates to avoid missing DOM elements

### DIFF
--- a/src/components/Charts/Chart.vue
+++ b/src/components/Charts/Chart.vue
@@ -5,6 +5,8 @@
 <script>
     import { Chart } from 'frappe-charts/dist/frappe-charts.min.esm'
 
+    let updateTimer
+    
     export default {
         props: {
             id: {
@@ -186,16 +188,16 @@
 
         watch: {
             labels() {
-                this.update()
+                this.updateDebounced()
             },
             dataSets() {
-                this.update()
+                this.updateDebounced()
             },
             yMarkers() {
-                this.update()
+                this.updateDebounced()
             },
             yRegions() {
-                this.update()
+                this.updateDebounced()
             }
         },
 
@@ -253,6 +255,15 @@
                 this.chart.updateDataset(datasetValues, index)
             },
 
+            updateDebounced () {
+                if(updateTimer) {
+                    window.clearTimeout(updateTimer)
+                    updateTimer = null
+                }
+                updateTimer = window.setTimeout(() => {
+                    this.update()
+                }, 1)
+            },
             update () {
                 const data = {
                     labels: this.labels,


### PR DESCRIPTION
When multiple props change at the same time, I was getting an error from the Chart library: Cannot read property 'replaceChild' of null at eval (frappe-charts.min.esm.js?4215:1)

I think the issue are the multiple updates sent in quick successions, and they step on each others' toes. I'm not certain, but delaying the updates by just one milliseconds seems to fix it for me. (I tried the native Vue "nextTick" but that didn't work)

Thanks for a great wrapper!