### PR TITLE
fixed issue with datasets update

### DIFF
--- a/src/components/Charts/Chart.vue
+++ b/src/components/Charts/Chart.vue
@@ -5,7 +5,7 @@
 <script>
 import { Chart } from "frappe-charts/dist/frappe-charts.min.esm";
 
-let updateTimer;
+let updateTimer = [];
 
 export default {
   props: {
@@ -252,11 +252,11 @@ export default {
     },
 
     updateDebounced() {
-      if (updateTimer) {
-        window.clearTimeout(updateTimer);
-        updateTimer = null;
+      if (updateTimer && updateTimer[this.id]) {
+        window.clearTimeout(updateTimer[this.id]);
+        updateTimer[this.id] = null;
       }
-      updateTimer = window.setTimeout(() => {
+      updateTimer[this.id] = window.setTimeout(() => {
         this.update();
       }, 1);
     },


### PR DESCRIPTION
Issue: When you display multiple times `<vue-frappe />` component on the same page, when you'll update the `dataSets` values, only the last chart will display new data. 

Solution: store `setTimeout` as array assoc with chart id